### PR TITLE
Add systemd drop-in override for Intel T2 Macs

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -8,8 +8,10 @@ license=('MIT')
 depends=('linux-t2' 'pango' 'libinput' 'gdk-pixbuf2' 'ttf-ubuntu-font-family' 'librsvg')
 conflicts=('touchbard')
 makedepends=('git' 'cargo' 'librsvg')
-source=("git+https://github.com/AsahiLinux/tiny-dfr")
-sha256sums=('SKIP')
+source=("git+https://github.com/AsahiLinux/tiny-dfr"
+        "t2-intel.conf")
+sha256sums=('SKIP'
+            'SKIP')
 
 pkgver() {
   cd "$pkgname"
@@ -34,6 +36,8 @@ package() {
 	install -Dm755 "$pkgname/target/release/tiny-dfr" "$pkgdir/usr/bin/tiny-dfr"
 	# Install systemd service
   install -Dm644 "$pkgname/etc/systemd/system/tiny-dfr.service" "$pkgdir/usr/lib/systemd/system/tiny-dfr.service"
+  # Install drop-in override for Intel T2 Macs (removes Apple Silicon device bindings)
+  install -Dm644 "$srcdir/t2-intel.conf" "$pkgdir/usr/lib/systemd/system/tiny-dfr.service.d/t2-intel.conf"
   install -Dm644 "$pkgname/etc/systemd/system/systemd-backlight@backlight:228200000.display-pipe.0.service" "$pkgdir/usr/lib/systemd/system/systemd-backlight@backlight:228200000.display-pipe.0.service"
 	install -Dm644 "$pkgname/etc/systemd/system/systemd-backlight@backlight:appletb_backlight.service" "$pkgdir/usr/lib/systemd/system/systemd-backlight@backlight:appletb_backlight.service"
 	# Install udev rule

--- a/t2-intel.conf
+++ b/t2-intel.conf
@@ -1,0 +1,12 @@
+# Override for Intel T2 Macs
+# The upstream service file has BindsTo= dependencies on Apple Silicon
+# device nodes that don't exist on Intel T2 Macs, preventing auto-start.
+
+[Unit]
+# Clear Apple Silicon device bindings
+BindsTo=
+# Start after graphical target instead
+After=graphical.target
+
+[Install]
+WantedBy=graphical.target


### PR DESCRIPTION
## Summary

The upstream `tiny-dfr.service` file has `BindsTo=` dependencies on Apple Silicon device nodes (`dev-tiny_dfr_display.device`, `dev-tiny_dfr_backlight.device`, `dev-tiny_dfr_display_backlight.device`) that don't exist on Intel T2 Macs. This prevents the service from auto-starting on boot.

## Solution

This PR adds a systemd drop-in override (`t2-intel.conf`) that:
- Clears the Apple Silicon device bindings
- Adds `After=graphical.target` for proper startup ordering  
- Adds an `[Install]` section with `WantedBy=graphical.target`

This approach keeps the upstream service file intact while providing T2-specific overrides, making it easier to maintain as upstream evolves.

## Testing

Tested on MacBook Pro 16,1 (2019) running Arch Linux with linux-t2 6.17.7-1. After applying this fix, `systemctl enable tiny-dfr.service` works correctly and the service auto-starts on boot.

## Related

This issue affects all Intel T2 Mac users. Without this fix, users must manually create a systemd override to get the Touch Bar working on boot.